### PR TITLE
Explicitly pass test_results to notifier's failed() and resolved() methods

### DIFF
--- a/Changelog.rdoc
+++ b/Changelog.rdoc
@@ -1,15 +1,15 @@
 ==Ragios v0.6.0
 
 04-18-2014
-* The monitor in its current state is now passed to the notifiers failed() and resolved() methods when they are invoked by Ragios. This ensures that notifiers have the ability to always have access to the most current of the monitor, ensures that test_results on notifiers are accurate.
+* The test_result is now explicitly passed to the notifier's failed() and resolved() methods are argument. This is an overall better design and ensures that notifiers report accurate results.
 
 New Specification for notifers
   module Ragios
     module Notifier
       class Dummy
         def initialize(monitor); end
-        def failed(monitor); end
-        def resolved(monitor); end
+        def failed(test_result); end
+        def resolved(test_result); end
       end
    end
   end

--- a/lib/ragios/generic_monitor.rb
+++ b/lib/ragios/generic_monitor.rb
@@ -69,7 +69,7 @@ private
       if exceed_failure_tolerance
         unless @failure_notified
           @notifiers.each do |notifier|
-            NotifyJob.new.async.failed(@options, notifier)
+            NotifyJob.new.async.failed(@test_result, notifier)
             @failure_notified = true
           end
         end
@@ -79,7 +79,7 @@ private
     def is_fixed
       reset_failure_count!
       @notifiers.each do |notifier|
-        NotifyJob.new.async.resolved(@options, notifier)
+        NotifyJob.new.async.resolved(@test_result, notifier)
       end
     end
 

--- a/lib/ragios/messages/email_failed.erb
+++ b/lib/ragios/messages/email_failed.erb
@@ -2,7 +2,7 @@
 
 <%= @monitor[:monitor] %> FAILED
 
-<% @monitor[:test_result_].each do |key,value| %>
+<% @test_result.each do |key,value| %>
 <%= key %>: <%= value %>
 <% end %>
 

--- a/lib/ragios/messages/email_resolved.erb
+++ b/lib/ragios/messages/email_resolved.erb
@@ -2,7 +2,7 @@
 
 <%= @monitor[:monitor] %> PASSED
 
-<% @monitor[:test_result_].each do |key,value| %>
+<% @test_result.each do |key,value| %>
 <%= key %>: <%= value %>
 <% end %>
 

--- a/lib/ragios/messages/tweet_error.erb
+++ b/lib/ragios/messages/tweet_error.erb
@@ -1,1 +1,0 @@
-<%= @test_description %> ERROR: <%= $! %> Created on: <%= Time.now.to_s %> 

--- a/lib/ragios/notifiers/dummy.rb
+++ b/lib/ragios/notifiers/dummy.rb
@@ -2,8 +2,8 @@ module Ragios
   module Notifier
     class Dummy
       def initialize(monitor); end
-      def failed(monitor); end
-      def resolved(monitor); end
+      def failed(test_result); end
+      def resolved(test_result); end
     end
  end
 end

--- a/lib/ragios/notifiers/email/email_notifier.rb
+++ b/lib/ragios/notifiers/email/email_notifier.rb
@@ -11,13 +11,13 @@ module Ragios
                   :subject => @subject,
                   :body => @body}
     end
-    def failed(monitor)
-      @monitor = monitor
+    def failed(test_result)
+      @test_result = test_result
       deliver(message("email_failed.erb"))
     end
 
-    def resolved(monitor)
-      @monitor = monitor
+    def resolved(test_result)
+      @test_result = test_result
       deliver(message("email_resolved.erb"))
     end
     def error

--- a/lib/ragios/notifiers/mock_notifier.rb
+++ b/lib/ragios/notifiers/mock_notifier.rb
@@ -4,15 +4,13 @@ module Ragios
       def initialize(monitor)
         @monitor = monitor
       end
-      def failed(monitor)
-        @monitor = monitor
+      def failed(test_result)
         puts "#{@monitor[:monitor]} FAILED"
-        puts "#{@monitor[:test_result_].inspect}"
+        puts "#{test_result.inspect}"
       end
-      def resolved(monitor)
-        @monitor = monitor
+      def resolved(test_result)
         puts "#{@monitor[:monitor]} RESOLVED"
-        puts "#{@monitor[:test_result_].inspect}"
+        puts "#{test_result.inspect}"
       end
     end
  end

--- a/lib/ragios/notifiers/twitter_notifier.rb
+++ b/lib/ragios/notifiers/twitter_notifier.rb
@@ -26,13 +26,11 @@ module Ragios
         message_template.result(binding)
       end
 
-      def resolved(monitor)
-        @monitor = monitor
+      def resolved(test_result)
         tweet(message("tweet_resolved.erb"))
       end
 
-      def failed(monitor)
-        @monitor = monitor
+      def failed(test_result)
         tweet(message("tweet_failed.erb"))
       end
     end

--- a/lib/ragios/notify_job.rb
+++ b/lib/ragios/notify_job.rb
@@ -2,12 +2,12 @@ module Ragios
   class NotifyJob
     include SuckerPunch::Job
 
-    def failed(monitor, notifier)
-      notifier.failed(monitor) if notifier.respond_to?('failed')
+    def failed(test_result, notifier)
+      notifier.failed(test_result) if notifier.respond_to?('failed')
     end
 
-    def resolved(monitor, notifier)
-      notifier.resolved(monitor) if notifier.respond_to?('resolved')
+    def resolved(test_result, notifier)
+      notifier.resolved(test_result) if notifier.respond_to?('resolved')
     end
   end
 end

--- a/spec/integration/restart_all_spec.rb
+++ b/spec/integration/restart_all_spec.rb
@@ -7,10 +7,10 @@ module Ragios
       def initialize(monitor)
         @monitor = monitor
       end
-      def failed
+      def failed(test_result)
         puts "#{@monitor.options[:_id]} FAILED"
       end
-      def resolved
+      def resolved(test_result)
         puts "#{@monitor.options[:_id]} RESOLVED"
       end
     end

--- a/spec/integration/ruby_api_spec.rb
+++ b/spec/integration/ruby_api_spec.rb
@@ -6,12 +6,10 @@ module Ragios
       def initialize(monitor)
         @monitor = monitor
       end
-      def failed(monitor)
-        @monitor = monitor
+      def failed(test_result)
         puts "#{@monitor[:_id]} FAILED"
       end
-      def resolved(monitor)
-        @monitor = monitor
+      def resolved(test_result)
         puts "#{@monitor[:_id]} RESOLVED"
       end
     end
@@ -52,12 +50,10 @@ module Ragios
       def initialize(monitor)
         @monitor = monitor
       end
-      def failed(monitor)
-        @monitor = monitor
+      def failed(test_result)
         puts "First Notifier FAILED for #{@monitor[:_id]}"
       end
-      def resolved(monitor)
-        @monitor = monitor
+      def resolved(test_result)
         puts "First Notifier RESOLVED for #{@monitor[:_id]}"
       end
     end
@@ -70,12 +66,10 @@ module Ragios
       def initialize(monitor)
         @monitor = monitor
       end
-      def failed(monitor)
-        @monitor = monitor
+      def failed(test_result)
         puts "Second Notifier FAILED for #{@monitor[:_id]}"
       end
-      def resolved(monitor)
-        @monitor = monitor
+      def resolved(test_result)
         puts "Second Notifier RESOLVED for #{@monitor[:_id]}"
       end
     end

--- a/spec/notifiers/twitter_notifier_spec.rb
+++ b/spec/notifiers/twitter_notifier_spec.rb
@@ -3,7 +3,7 @@ require 'notifier_test_setup.rb'
 
 describe Ragios::Notifier::TwitterNotifier do
   it "tests a monitor" do
-    Ragios::NotifierTest::failed_resolved('Twitter test','twitter_notifier')     
+    Ragios::NotifierTest::failed_resolved('Twitter test','twitter_notifier')
   end
 
   it "should send a tweet a notification message " do

--- a/spec/unit_tests/controller_spec.rb
+++ b/spec/unit_tests/controller_spec.rb
@@ -5,9 +5,9 @@ module Ragios
     class MockNotifier
       def initialize(monitor)
       end
-      def failed(monitor)
+      def failed(test_result)
       end
-      def resolved(monitor)
+      def resolved(test_result)
       end
     end
  end

--- a/spec/unit_tests/generic_monitor_spec.rb
+++ b/spec/unit_tests/generic_monitor_spec.rb
@@ -5,9 +5,9 @@ module Ragios
     class TestNotifier
       def initialize(monitor)
       end
-      def failed(monitor)
+      def failed(test_result)
       end
-      def resolved(monitor)
+      def resolved(test_result)
       end
     end
  end


### PR DESCRIPTION
This makes sense for the overall design, easier to reason about and ensures that notifiers are reporting correct data.
