### PR TITLE
Handle app error

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,16 +1,24 @@
 #config.ru
-require 'rubygems'
-require "bundler/setup"
-dir = Pathname(__FILE__).dirname.expand_path
-require dir + 'config'
-require dir + 'lib/ragios/rest_server'
+begin
+  require 'rubygems'
+  require "bundler/setup"
+  dir = Pathname(__FILE__).dirname.expand_path
+  require dir + 'config'
+  require dir + 'lib/ragios/rest_server'
 
-run App
+  run App
 
-def require_all(path)
-  Dir.glob(File.dirname(__FILE__) + path + '/*.rb') do |file|
-    require File.dirname(__FILE__)  + path + '/' + File.basename(file, File.extname(file))
+  def require_all(path)
+    Dir.glob(File.dirname(__FILE__) + path + '/*.rb') do |file|
+      require File.dirname(__FILE__)  + path + '/' + File.basename(file, File.extname(file))
+    end
   end
-end
 
-require_all '/initializers'
+  require_all '/initializers'
+rescue => e
+  $stderr.puts '-' * 80
+  $stderr.puts "Application Error: #{e.class}: '#{e.message}'"
+  $stderr.puts e.backtrace.join("\n")
+  $stderr.puts '-' * 80
+  raise e
+end

--- a/lib/ragios/couchdb_admin.rb
+++ b/lib/ragios/couchdb_admin.rb
@@ -11,7 +11,8 @@ module Ragios
       begin
         @database.create
       rescue Leanback::CouchdbException => e
-        raise e if e.response[:error] == "unauthorized"
+        unauthorized = (e.response[:error] == "unauthorized") rescue false
+        raise e if unauthorized
       end
 
       if @database_config[:username]


### PR DESCRIPTION
Handle errors loading ragios app on puma, also handle errors from different couchdb implementation as cloudant returns a slightly different error in this case