### PR TITLE
Ragios Production Mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rufus-scheduler', '~> 3.4.2', :require => 'rufus/scheduler'
 gem 'state_machine'
-gem 'leanback', '~> 0.5.1'
+gem 'leanback', '~> 0.5.8'
 gem 'contracts'
 gem 'celluloid-zmq', '~> 0.17.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,9 +50,9 @@ GEM
     hitimes (1.2.4-java)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    leanback (0.5.4)
-      multi_json
-      rest-client
+    leanback (0.5.8)
+      multi_json (~> 1.11)
+      rest-client (~> 2.0)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
     method_source (0.8.1)
@@ -119,7 +119,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf (0.1.4-java)
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     xml-simple (1.1.5)
 
 PLATFORMS
@@ -133,7 +133,7 @@ DEPENDENCIES
   daemons
   excon
   foreman
-  leanback (~> 0.5.1)
+  leanback (~> 0.5.8)
   pry
   puma (~> 3.10.0)
   rack-test

--- a/bin/database_setup.rb
+++ b/bin/database_setup.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+require 'leanback'
+
+database = Leanback::Couchdb.new(
+  address: ENV['RAGIOS_COUCHDB_ADDRESS'],
+  port: ENV['RAGIOS_COUCHDB_PORT']
+)
+
+begin
+  username = ENV['COUCHDB_ADMIN_USERNAME']
+  password = ENV['COUCHDB_ADMIN_PASSWORD']
+
+  if password && username
+    database.set_config(
+      "admins",
+      username = username,
+      password = "\"#{password}\""
+    )
+    puts "CouchDB Admin user successfully created"
+  else
+    puts "No CouchDB Admin user configured"
+  end
+rescue RestClient::Unauthorized => e
+  puts "CouchDB Admin user already created"
+end

--- a/docker-compose-test-local.yml
+++ b/docker-compose-test-local.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   couchdb:
-    image: "klaemo/couchdb"
+    image: "apache/couchdb:1.7.1"
     expose:
       - "5984"
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   couchdb:
-    image: "klaemo/couchdb"
+    image: "apache/couchdb:1.7.1"
     expose:
       - "5984"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,27 @@
 version: '3'
 services:
   couchdb:
-    image: "klaemo/couchdb"
+    image: "apache/couchdb:1.7.1"
     expose:
       - "5984"
     ports:
       - 5984:5984
 
+  database_setup:
+    image: "obiora/ragios:ragios-production-mode"
+    links:
+      - couchdb:couchdb
+    environment:
+      COUCHDB_ADMIN_USERNAME:
+      COUCHDB_ADMIN_PASSWORD:
+    tty: true
+    stdin_open: true
+    entrypoint: bundle exec ruby bin/database_setup.rb
+
   web:
     image: "obiora/ragios:latest"
+    depends_on:
+      - database_setup
     links:
       - couchdb:couchdb
       - recurring_jobs:recurring_jobs
@@ -40,6 +53,8 @@ services:
 
   recurring_jobs:
     image: "obiora/ragios:latest"
+    depends_on:
+      - database_setup
     links:
       - couchdb:couchdb
       - events:events
@@ -64,6 +79,8 @@ services:
 
   workers:
     image: "obiora/ragios:latest"
+    depends_on:
+      - database_setup
     links:
       - couchdb:couchdb
       - events:events
@@ -88,6 +105,8 @@ services:
 
   events:
     image: "obiora/ragios:latest"
+    depends_on:
+      - database_setup
     links:
       - couchdb:couchdb
     environment:
@@ -104,6 +123,8 @@ services:
 
   notifications:
     image: "obiora/ragios:latest"
+    depends_on:
+      - database_setup
     links:
       - couchdb:couchdb
       - events:events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 5984:5984
 
   database_setup:
-    image: "obiora/ragios:ragios-production-mode"
+    image: "obiora/ragios:latest"
     links:
       - couchdb:couchdb
     environment:


### PR DESCRIPTION
Prep Ragios to run in a production environment. Add defaults and config required to run Ragios in production.
- [ ] Add a docker-compose health check for all services (Couchdb, web, events, notifications, workers), so that they can be auto-restarted in production when they go down
- [x] Fix issue with Ragios services containers crashing when CouchDB has not fully started in its container, because they can't connect to the database
- [x]  add configuration startup script for CouchDB - that sets up CouchDB credentials username, password and DB configuration. Take a cue from how Rails handles this. 

## config defaults for couchdb
- [x] Set database username & password, remove admin party for couchDB
- [ ] Add auto-compaction for couchDB -< downgraded to CouchDB 1.7.1 with no auto-compaction
- [ ] investigate running multiple nodes for couchDB -< downgraded to CouchDB 1.7.1 without this 

Test it with Ragios admin party disabled
